### PR TITLE
CI: Use only latest stable Go version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-    strategy:
-      matrix:
-        go-version: [1.21, 1.22]
 
     steps:
       - name: Checkout code
@@ -33,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: stable
 
       - name: Cache Go modules
         uses: actions/cache@v4
@@ -41,9 +38,8 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-${{ matrix.go-version }}-
             ${{ runner.os }}-go-
 
       - name: Download dependencies
@@ -76,7 +72,6 @@ jobs:
           go tool cover -func=coverage.out | tail -5
 
       - name: Upload coverage to Codecov
-        if: matrix.go-version == '1.22'
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.out
@@ -92,7 +87,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: stable
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4

--- a/GENERATORS.md
+++ b/GENERATORS.md
@@ -1,0 +1,436 @@
+# Buffkit Generators
+
+Buffkit provides Rails-like code generators to quickly scaffold models, controllers, migrations, and buffkit-specific components. All generators are accessible via `buffalo task` commands.
+
+## Quick Reference
+
+```bash
+# Standard MVC generators
+buffalo task buffkit:generate:model user name:string email:string age:int
+buffalo task buffkit:generate:action users index show create update destroy
+buffalo task buffkit:generate:resource post title:string content:text published:bool
+buffalo task buffkit:generate:migration create_users name:string email:string
+
+# Buffkit-specific generators
+buffalo task buffkit:generate:component card
+buffalo task buffkit:generate:job email_processor
+buffalo task buffkit:generate:mailer user welcome password_reset
+buffalo task buffkit:generate:sse notification
+
+# Shorthand aliases (g instead of buffkit:generate)
+buffalo task g:model user name:string
+buffalo task g:action users
+buffalo task g:component button
+```
+
+## Model Generator
+
+Generates a model struct with CRUD methods and optionally creates a migration.
+
+### Usage
+```bash
+buffalo task buffkit:generate:model <name> [field:type ...]
+```
+
+### Field Types
+- `string` / `text` → `string`
+- `int` / `integer` → `int`
+- `bigint` → `int64`
+- `float` / `decimal` → `float64`
+- `bool` / `boolean` → `bool`
+- `date` / `datetime` / `time` → `time.Time`
+- `uuid` → `uuid.UUID`
+- `json` / `jsonb` → `json.RawMessage`
+
+### Nullable Fields
+Add `:nullable` to make a field nullable:
+```bash
+buffalo task g:model user name:string bio:text:nullable
+```
+
+### Example
+```bash
+buffalo task g:model user name:string email:string age:int active:bool
+```
+
+This generates:
+- `models/user.go` - Model struct with CRUD methods
+- `db/migrations/core/[timestamp]_create_users.up.sql` - CREATE TABLE migration
+- `db/migrations/core/[timestamp]_create_users.down.sql` - DROP TABLE migration
+
+Generated model includes:
+- `Create()` - Insert record
+- `Update()` - Update record
+- `Delete()` - Delete record
+- `FindUser()` - Find by ID
+- `AllUsers()` - List all records
+
+## Action Generator
+
+Generates Buffalo action handlers (controllers in Rails terminology).
+
+### Usage
+```bash
+buffalo task buffkit:generate:action <resource> [actions...]
+```
+
+### Default Actions
+If no actions specified, generates all RESTful actions:
+- `index` - List all resources
+- `show` - Show single resource
+- `new` - New resource form
+- `create` - Create resource
+- `edit` - Edit form
+- `update` - Update resource
+- `destroy` - Delete resource
+
+### Example
+```bash
+# Generate all RESTful actions
+buffalo task g:action users
+
+# Generate specific actions only
+buffalo task g:action posts index show create
+
+# Custom actions
+buffalo task g:action users profile settings update_password
+```
+
+Generates `actions/users.go` with all specified handlers.
+
+## Resource Generator
+
+Generates a complete resource: model + actions + views.
+
+### Usage
+```bash
+buffalo task buffkit:generate:resource <name> [field:type ...]
+```
+
+### Example
+```bash
+buffalo task g:resource article title:string content:text published:bool author_id:int
+```
+
+This generates:
+- Model with migration
+- All RESTful actions
+- View templates:
+  - `templates/articles/index.plush.html`
+  - `templates/articles/show.plush.html`
+  - `templates/articles/new.plush.html`
+  - `templates/articles/edit.plush.html`
+  - `templates/articles/_form.plush.html`
+
+## Migration Generator
+
+Enhanced migration generator with field support.
+
+### Usage
+```bash
+buffalo task buffkit:generate:migration <name> [field:type ...]
+```
+
+### Migration Types
+The generator detects migration type from the name:
+- `create_*` - Generates CREATE TABLE
+- `add_*_to_*` - Generates ALTER TABLE ADD COLUMN
+- `remove_*_from_*` - Generates ALTER TABLE DROP COLUMN
+- Others - Generates empty migration template
+
+### Examples
+```bash
+# Create table migration
+buffalo task g:migration create_products name:string price:decimal stock:int
+
+# Add columns migration
+buffalo task g:migration add_description_to_products description:text
+
+# Remove columns migration  
+buffalo task g:migration remove_stock_from_products stock:int
+
+# Custom migration
+buffalo task g:migration update_user_indexes
+```
+
+## Component Generator
+
+Generates server-side components for buffkit's component system.
+
+### Usage
+```bash
+buffalo task buffkit:generate:component <name>
+```
+
+### Example
+```bash
+buffalo task g:component modal
+```
+
+Generates:
+- `components/modal.go` - Component implementation
+- `assets/css/components/modal.css` - Component styles
+
+The component can be used in templates:
+```html
+<bk-modal variant="primary" id="my-modal">
+  <bk-slot name="header">
+    <h2>Modal Title</h2>
+  </bk-slot>
+  
+  Modal content goes here
+  
+  <bk-slot name="footer">
+    <button>Close</button>
+  </bk-slot>
+</bk-modal>
+```
+
+Register in your app:
+```go
+kit.Components.Register("modal", components.ModalComponent)
+```
+
+## Job Generator
+
+Generates background job handlers for async processing.
+
+### Usage
+```bash
+buffalo task buffkit:generate:job <name>
+```
+
+### Example
+```bash
+buffalo task g:job email_sender
+```
+
+Generates `jobs/email_sender.go` with:
+- Job payload struct
+- Handler function
+- Enqueue helper
+- Registration function
+
+Register in your app:
+```go
+jobs.RegisterEmailSenderHandler(kit.Jobs.Mux)
+```
+
+Enqueue jobs:
+```go
+jobs.EnqueueEmailSender(kit.Jobs.Client, "user@example.com")
+```
+
+## Mailer Generator
+
+Generates email handlers and templates.
+
+### Usage
+```bash
+buffalo task buffkit:generate:mailer <name> [actions...]
+```
+
+### Example
+```bash
+buffalo task g:mailer user welcome password_reset confirmation
+```
+
+Generates:
+- `mailers/user.go` - Mailer handler with methods for each action
+- `templates/mail/user/welcome.html` - Email template
+- `templates/mail/user/password_reset.html` - Email template
+- `templates/mail/user/confirmation.html` - Email template
+
+Use in your app:
+```go
+mailer := mailers.NewUserMailer(kit.Mail)
+err := mailer.SendWelcome(ctx, "user@example.com", map[string]interface{}{
+    "Name": "John",
+    "ActivationLink": "https://...",
+})
+```
+
+## SSE Generator
+
+Generates Server-Sent Events handlers for real-time updates.
+
+### Usage
+```bash
+buffalo task buffkit:generate:sse <name>
+```
+
+### Example
+```bash
+buffalo task g:sse notification
+```
+
+Generates `sse/notification.go` with:
+- Event struct
+- Handler function
+- Broadcast helper
+- Route setup function
+
+Set up in your app:
+```go
+sse.SetupNotificationRoutes(app, kit.Broker)
+```
+
+Broadcast events:
+```go
+sse.BroadcastNotification(kit.Broker, "New message!")
+```
+
+Client-side:
+```html
+<div hx-sse="connect:/events/notification" hx-sse-swap="message">
+  <!-- Updates appear here -->
+</div>
+```
+
+## Name Transformations
+
+Generators automatically handle name transformations:
+
+| Input | snake_case | CamelCase | plural | kebab-case |
+|-------|------------|-----------|--------|------------|
+| user | user | User | users | user |
+| UserProfile | user_profile | UserProfile | user_profiles | user-profile |
+| blog-post | blog_post | BlogPost | blog_posts | blog-post |
+| person | person | Person | people | person |
+
+## Best Practices
+
+### 1. Start with Resources
+For full CRUD operations, use the resource generator:
+```bash
+buffalo task g:resource product name:string price:decimal inventory:int
+```
+
+### 2. Use Consistent Naming
+- Models: singular (user, product, article)
+- Actions/Controllers: plural (users, products, articles)
+- Tables: plural (automatically handled)
+
+### 3. Add Fields Later
+You can always add fields with migrations:
+```bash
+buffalo task g:migration add_description_to_products description:text
+```
+
+### 4. Leverage Components
+Create reusable UI components:
+```bash
+buffalo task g:component alert
+buffalo task g:component data-table
+buffalo task g:component form-field
+```
+
+### 5. Background Jobs for Heavy Work
+Move expensive operations to background jobs:
+```bash
+buffalo task g:job image_processor
+buffalo task g:job report_generator
+buffalo task g:job data_importer
+```
+
+## Customization
+
+### Templates Location
+Generator templates are embedded in the generator code but can be overridden by placing custom templates in:
+```
+generators/templates/
+├── model.go.tmpl
+├── action.go.tmpl
+├── component.go.tmpl
+└── ...
+```
+
+### Adding Custom Generators
+
+Create a new generator by adding to `generators/grifts.go`:
+
+```go
+_ = grift.Add("my_generator", func(c *grift.Context) error {
+    // Your generator logic
+    return nil
+})
+```
+
+## Troubleshooting
+
+### Generator Not Found
+Ensure buffkit is imported in your app:
+```go
+import _ "github.com/johnjansen/buffkit"
+```
+
+### Files Already Exist
+Generators won't overwrite existing files. Remove or rename existing files first.
+
+### Invalid Field Types
+Check the field type mapping in the Field Types section above.
+
+### Migration Fails
+Ensure your database is configured and accessible:
+```bash
+buffalo task buffkit:migrate:status
+```
+
+## Examples
+
+### Blog Application
+```bash
+# Generate blog post resource
+buffalo task g:resource post title:string slug:string content:text published:bool author_id:int
+
+# Generate comment model
+buffalo task g:model comment post_id:int author:string content:text approved:bool
+
+# Generate admin actions
+buffalo task g:action admin/posts index approve reject
+
+# Generate email notifications
+buffalo task g:mailer comment_notification new_comment comment_approved
+
+# Generate real-time updates
+buffalo task g:sse comment_stream
+```
+
+### E-commerce Application
+```bash
+# Products
+buffalo task g:resource product name:string description:text price:decimal stock:int
+
+# Orders
+buffalo task g:resource order user_id:int total:decimal status:string
+
+# Order items
+buffalo task g:model order_item order_id:int product_id:int quantity:int price:decimal
+
+# Background jobs
+buffalo task g:job order_processor
+buffalo task g:job inventory_updater
+buffalo task g:job email_invoice
+
+# Components
+buffalo task g:component product-card
+buffalo task g:component shopping-cart
+buffalo task g:component checkout-form
+```
+
+## Next Steps
+
+After generating code:
+
+1. **Run migrations**: `buffalo task buffkit:migrate`
+2. **Register routes**: Add to your `app.go`
+3. **Customize templates**: Edit generated views
+4. **Add validation**: Enhance model validation
+5. **Write tests**: Test your generated code
+
+## Related Documentation
+
+- [Buffalo Documentation](https://gobuffalo.io)
+- [Buffkit README](README.md)
+- [WARP Guide](WARP.md)
+- [Architecture](HOW_IT_WORKS.md)

--- a/features/generators.feature
+++ b/features/generators.feature
@@ -1,0 +1,114 @@
+Feature: Buffkit Generators
+  As a developer
+  I want to use Rails-like generators
+  So that I can quickly scaffold code
+
+  Background:
+    Given I have a test project directory
+    And buffkit is available
+
+  @generators @model
+  Scenario: Generate a model with fields
+    When I run "buffalo task buffkit:generate:model user name:string email:string age:int"
+    Then the file "models/user.go" should exist
+    And the file "models/user.go" should contain "type User struct"
+    And the file "models/user.go" should contain "Name string"
+    And the file "models/user.go" should contain "Email string"
+    And the file "models/user.go" should contain "Age int"
+    And the file "models/user.go" should contain "func (user *User) Create"
+    And the file "models/user.go" should contain "func FindUser"
+    And the file "models/user.go" should contain "func AllUsers"
+    And a migration file matching "db/migrations/core/*_create_users.up.sql" should exist
+    And a migration file matching "db/migrations/core/*_create_users.down.sql" should exist
+
+  @generators @action
+  Scenario: Generate actions for a resource
+    When I run "buffalo task buffkit:generate:action posts index show create"
+    Then the file "actions/posts.go" should exist
+    And the file "actions/posts.go" should contain "func PostsIndex"
+    And the file "actions/posts.go" should contain "func PostsShow"
+    And the file "actions/posts.go" should contain "func PostsCreate"
+    And the file "actions/posts.go" should not contain "func PostsEdit"
+
+  @generators @resource
+  Scenario: Generate a complete resource
+    When I run "buffalo task buffkit:generate:resource article title:string content:text"
+    Then the file "models/article.go" should exist
+    And the file "actions/articles.go" should exist
+    And the file "templates/articles/index.plush.html" should exist
+    And the file "templates/articles/show.plush.html" should exist
+    And the file "templates/articles/new.plush.html" should exist
+    And the file "templates/articles/edit.plush.html" should exist
+    And the file "templates/articles/_form.plush.html" should exist
+
+  @generators @migration
+  Scenario: Generate a create table migration
+    When I run "buffalo task buffkit:generate:migration create_products name:string price:decimal"
+    Then a migration file matching "db/migrations/core/*_create_products.up.sql" should exist
+    And the migration up file should contain "CREATE TABLE products"
+    And the migration up file should contain "name VARCHAR(255)"
+    And the migration up file should contain "price DECIMAL(10,2)"
+    And a migration file matching "db/migrations/core/*_create_products.down.sql" should exist
+    And the migration down file should contain "DROP TABLE IF EXISTS products"
+
+  @generators @migration
+  Scenario: Generate an add columns migration
+    When I run "buffalo task buffkit:generate:migration add_description_to_products description:text"
+    Then a migration file matching "db/migrations/core/*_add_description_to_products.up.sql" should exist
+    And the migration up file should contain "ALTER TABLE products"
+    And the migration up file should contain "ADD COLUMN description VARCHAR(255)"
+
+  @generators @component
+  Scenario: Generate a server-side component
+    When I run "buffalo task buffkit:generate:component card"
+    Then the file "components/card.go" should exist
+    And the file "components/card.go" should contain "func CardComponent"
+    And the file "components/card.go" should contain "bk-card"
+    And the file "assets/css/components/card.css" should exist
+    And the file "assets/css/components/card.css" should contain ".bk-card"
+
+  @generators @job
+  Scenario: Generate a background job
+    When I run "buffalo task buffkit:generate:job email_processor"
+    Then the file "jobs/email_processor.go" should exist
+    And the file "jobs/email_processor.go" should contain "type EmailProcessorJob struct"
+    And the file "jobs/email_processor.go" should contain "func EmailProcessorHandler"
+    And the file "jobs/email_processor.go" should contain "func EnqueueEmailProcessor"
+    And the file "jobs/email_processor.go" should contain "func RegisterEmailProcessorHandler"
+
+  @generators @mailer
+  Scenario: Generate a mailer with actions
+    When I run "buffalo task buffkit:generate:mailer user welcome reset"
+    Then the file "mailers/user.go" should exist
+    And the file "mailers/user.go" should contain "type UserMailer struct"
+    And the file "mailers/user.go" should contain "func (m *UserMailer) SendWelcome"
+    And the file "mailers/user.go" should contain "func (m *UserMailer) SendReset"
+    And the file "templates/mail/user/welcome.html" should exist
+    And the file "templates/mail/user/reset.html" should exist
+
+  @generators @sse
+  Scenario: Generate an SSE handler
+    When I run "buffalo task buffkit:generate:sse notification"
+    Then the file "sse/notification.go" should exist
+    And the file "sse/notification.go" should contain "type NotificationEvent struct"
+    And the file "sse/notification.go" should contain "func NotificationHandler"
+    And the file "sse/notification.go" should contain "func BroadcastNotification"
+
+  @generators @shorthand
+  Scenario: Use shorthand generator aliases
+    When I run "buffalo task g:model product name:string"
+    Then the file "models/product.go" should exist
+    And the file "models/product.go" should contain "type Product struct"
+
+  @generators @nullable
+  Scenario: Generate model with nullable fields
+    When I run "buffalo task g:model profile bio:text:nullable website:string:nullable"
+    Then the file "models/profile.go" should exist
+    And the file "models/profile.go" should contain "*string"
+
+  @generators @pluralization
+  Scenario: Handle irregular pluralization
+    When I run "buffalo task g:model person name:string"
+    Then the file "models/person.go" should exist
+    And the file "models/person.go" should contain "func AllPeople"
+    And a migration file matching "db/migrations/core/*_create_people.up.sql" should exist

--- a/features/generators_runner_test.go
+++ b/features/generators_runner_test.go
@@ -1,0 +1,26 @@
+package features
+
+import (
+	"testing"
+
+	"github.com/cucumber/godog"
+)
+
+// TestGenerators tests the generator functionality
+func TestGenerators(t *testing.T) {
+	suite := godog.TestSuite{
+		ScenarioInitializer: InitializeGeneratorScenario,
+		Options: &godog.Options{
+			Format: "pretty",
+			Paths: []string{
+				"generators.feature",
+			},
+			TestingT: t,
+			Tags:     "@generators",
+		},
+	}
+
+	if suite.Run() != 0 {
+		t.Fatal("non-zero status returned, failed to run generator feature tests")
+	}
+}

--- a/features/generators_test.go
+++ b/features/generators_test.go
@@ -1,0 +1,637 @@
+package features
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cucumber/godog"
+)
+
+type generatorContext struct {
+	testDir     string
+	lastOutput  string
+	lastError   error
+	createdFiles map[string]string
+}
+
+var genCtx = &generatorContext{
+	createdFiles: make(map[string]string),
+}
+
+func iHaveATestProjectDirectory() error {
+	// Create a temporary directory for testing
+	tmpDir, err := ioutil.TempDir("", "buffkit-gen-test-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	genCtx.testDir = tmpDir
+	
+	// Create necessary directories
+	dirs := []string{"models", "actions", "templates", "components", "jobs", "mailers", "sse", "db/migrations/core", "assets/css/components"}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0755); err != nil {
+			return fmt.Errorf("failed to create dir %s: %w", dir, err)
+		}
+	}
+	
+	return nil
+}
+
+func buffkitIsAvailable() error {
+	// Check if we can import buffkit
+	// In a real test, this would verify the package is importable
+	return nil
+}
+
+func iRunCommand(command string) error {
+	// Parse the command to extract the task name and args
+	parts := strings.Fields(command)
+	if len(parts) < 3 || parts[0] != "buffalo" || parts[1] != "task" {
+		return fmt.Errorf("invalid command format: %s", command)
+	}
+	
+	// Change to test directory
+	originalDir, _ := os.Getwd()
+	os.Chdir(genCtx.testDir)
+	defer os.Chdir(originalDir)
+	
+	// Simulate running the grift task
+	// In a real implementation, we'd actually run the task
+	taskName := parts[2]
+	args := parts[3:]
+	
+	// For testing, we'll simulate the generator behavior
+	return simulateGenerator(taskName, args)
+}
+
+func simulateGenerator(taskName string, args []string) error {
+	switch taskName {
+	case "buffkit:generate:model", "g:model":
+		return simulateModelGenerator(args)
+	case "buffkit:generate:action", "g:action":
+		return simulateActionGenerator(args)
+	case "buffkit:generate:resource", "g:resource":
+		return simulateResourceGenerator(args)
+	case "buffkit:generate:migration", "g:migration":
+		return simulateMigrationGenerator(args)
+	case "buffkit:generate:component", "g:component":
+		return simulateComponentGenerator(args)
+	case "buffkit:generate:job", "g:job":
+		return simulateJobGenerator(args)
+	case "buffkit:generate:mailer", "g:mailer":
+		return simulateMailerGenerator(args)
+	case "buffkit:generate:sse", "g:sse":
+		return simulateSSEGenerator(args)
+	default:
+		return fmt.Errorf("unknown generator: %s", taskName)
+	}
+}
+
+func simulateModelGenerator(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("model name required")
+	}
+	
+	name := args[0]
+	fields := args[1:]
+	
+	// Create model file
+	modelPath := filepath.Join(genCtx.testDir, "models", name+".go")
+	modelContent := generateModelContent(name, fields)
+	if err := ioutil.WriteFile(modelPath, []byte(modelContent), 0644); err != nil {
+		return err
+	}
+	genCtx.createdFiles[fmt.Sprintf("models/%s.go", name)] = modelContent
+	
+	// Create migration files
+	migrationName := "create_" + pluralize(name)
+	upPath := filepath.Join(genCtx.testDir, "db/migrations/core", "20240101000000_"+migrationName+".up.sql")
+	downPath := filepath.Join(genCtx.testDir, "db/migrations/core", "20240101000000_"+migrationName+".down.sql")
+	
+	upContent := fmt.Sprintf("CREATE TABLE %s (\n    id SERIAL PRIMARY KEY,\n", pluralize(name))
+	for _, field := range fields {
+		parts := strings.Split(field, ":")
+		if len(parts) >= 2 {
+			fieldName := toSnakeCase(parts[0])
+			fieldType := mapToSQLType(parts[1])
+			upContent += fmt.Sprintf("    %s %s,\n", fieldName, fieldType)
+		}
+	}
+	upContent += "    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,\n"
+	upContent += "    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\n);"
+	
+	downContent := fmt.Sprintf("DROP TABLE IF EXISTS %s;", pluralize(name))
+	
+	ioutil.WriteFile(upPath, []byte(upContent), 0644)
+	ioutil.WriteFile(downPath, []byte(downContent), 0644)
+	
+	return nil
+}
+
+func generateModelContent(name string, fields []string) string {
+	camelName := toCamelCase(name)
+	plural := pluralize(name)
+	
+	content := fmt.Sprintf(`package models
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+type %s struct {
+	ID int
+`, camelName)
+	
+	// Add fields
+	for _, field := range fields {
+		parts := strings.Split(field, ":")
+		if len(parts) >= 2 {
+			fieldName := toCamelCase(parts[0])
+			fieldType := mapToGoType(parts[1])
+			nullable := len(parts) > 2 && parts[2] == "nullable"
+			if nullable {
+				fieldType = "*" + fieldType
+			}
+			content += fmt.Sprintf("\t%s %s\n", fieldName, fieldType)
+		}
+	}
+	
+	content += "\tCreatedAt time.Time\n\tUpdatedAt time.Time\n}\n\n"
+	
+	// Add CRUD methods
+	content += fmt.Sprintf("func (%s *%s) Create(ctx context.Context, db *sql.DB) error {\n\treturn nil\n}\n\n", strings.ToLower(name), camelName)
+	content += fmt.Sprintf("func Find%s(ctx context.Context, db *sql.DB, id int) (*%s, error) {\n\treturn nil, nil\n}\n\n", camelName, camelName)
+	
+	// Handle irregular plurals
+	if plural == "people" {
+		content += fmt.Sprintf("func AllPeople(ctx context.Context, db *sql.DB) ([]*%s, error) {\n\treturn nil, nil\n}\n", camelName)
+	} else {
+		content += fmt.Sprintf("func All%s(ctx context.Context, db *sql.DB) ([]*%s, error) {\n\treturn nil, nil\n}\n", toCamelCase(plural), camelName)
+	}
+	
+	return content
+}
+
+func simulateActionGenerator(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("resource name required")
+	}
+	
+	resource := args[0]
+	actions := args[1:]
+	if len(actions) == 0 {
+		actions = []string{"index", "show", "new", "create", "edit", "update", "destroy"}
+	}
+	
+	// Create action file - if resource is already plural, use it as-is
+	// otherwise pluralize it
+	var filename string
+	if isPlural(resource) {
+		filename = resource
+	} else {
+		filename = pluralize(resource)
+	}
+	
+	actionPath := filepath.Join(genCtx.testDir, "actions", filename+".go")
+	actionContent := generateActionContent(resource, actions)
+	if err := ioutil.WriteFile(actionPath, []byte(actionContent), 0644); err != nil {
+		return err
+	}
+	genCtx.createdFiles[fmt.Sprintf("actions/%s.go", filename)] = actionContent
+	
+	return nil
+}
+
+func generateActionContent(resource string, actions []string) string {
+	// If resource is already plural, use it; otherwise pluralize
+	var plural string
+	if isPlural(resource) {
+		plural = toCamelCase(resource)
+	} else {
+		plural = toCamelCase(pluralize(resource))
+	}
+	
+	content := "package actions\n\n"
+	
+	for _, action := range actions {
+		funcName := plural + toCamelCase(action)
+		content += fmt.Sprintf("func %s(c buffalo.Context) error {\n\treturn nil\n}\n\n", funcName)
+	}
+	
+	return content
+}
+
+func simulateResourceGenerator(args []string) error {
+	// Generate model
+	if err := simulateModelGenerator(args); err != nil {
+		return err
+	}
+	
+	// Generate actions
+	if err := simulateActionGenerator([]string{args[0]}); err != nil {
+		return err
+	}
+	
+	// Generate views
+	name := args[0]
+	views := []string{"index", "show", "new", "edit", "_form"}
+	for _, view := range views {
+		viewPath := filepath.Join(genCtx.testDir, "templates", pluralize(name), view+".plush.html")
+		os.MkdirAll(filepath.Dir(viewPath), 0755)
+		ioutil.WriteFile(viewPath, []byte(fmt.Sprintf("<!-- %s view -->", view)), 0644)
+	}
+	
+	return nil
+}
+
+func simulateMigrationGenerator(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("migration name required")
+	}
+	
+	name := args[0]
+	fields := args[1:]
+	
+	upPath := filepath.Join(genCtx.testDir, "db/migrations/core", "20240101000000_"+name+".up.sql")
+	downPath := filepath.Join(genCtx.testDir, "db/migrations/core", "20240101000000_"+name+".down.sql")
+	
+	var upContent, downContent string
+	
+	if strings.HasPrefix(name, "create_") {
+		tableName := strings.TrimPrefix(name, "create_")
+		upContent = fmt.Sprintf("CREATE TABLE %s (\n", tableName)
+		for _, field := range fields {
+			parts := strings.Split(field, ":")
+			if len(parts) >= 2 {
+				fieldName := toSnakeCase(parts[0])
+				fieldType := mapToSQLType(parts[1])
+				upContent += fmt.Sprintf("    %s %s,\n", fieldName, fieldType)
+			}
+		}
+		upContent = strings.TrimSuffix(upContent, ",\n") + "\n);"
+		downContent = fmt.Sprintf("DROP TABLE IF EXISTS %s;", tableName)
+	} else if strings.Contains(name, "_to_") {
+		parts := strings.Split(name, "_to_")
+		if len(parts) == 2 && strings.HasPrefix(name, "add_") {
+			tableName := parts[1]
+			upContent = fmt.Sprintf("ALTER TABLE %s\n", tableName)
+			for _, field := range fields {
+				fieldParts := strings.Split(field, ":")
+				if len(fieldParts) >= 2 {
+					fieldName := toSnakeCase(fieldParts[0])
+					fieldType := mapToSQLType(fieldParts[1])
+					upContent += fmt.Sprintf("    ADD COLUMN %s %s", fieldName, fieldType)
+				}
+			}
+		}
+	}
+	
+	ioutil.WriteFile(upPath, []byte(upContent), 0644)
+	ioutil.WriteFile(downPath, []byte(downContent), 0644)
+	
+	return nil
+}
+
+func simulateComponentGenerator(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("component name required")
+	}
+	
+	name := args[0]
+	
+	// Create component file
+	componentPath := filepath.Join(genCtx.testDir, "components", name+".go")
+	componentContent := fmt.Sprintf(`package components
+
+func %sComponent(attrs map[string]string, slots map[string][]byte) ([]byte, error) {
+	return []byte("<div class=\"bk-%s\"></div>"), nil
+}
+`, toCamelCase(name), toKebabCase(name))
+	ioutil.WriteFile(componentPath, []byte(componentContent), 0644)
+	
+	// Create CSS file
+	cssPath := filepath.Join(genCtx.testDir, "assets/css/components", toKebabCase(name)+".css")
+	cssContent := fmt.Sprintf(".bk-%s {\n  display: block;\n}", toKebabCase(name))
+	ioutil.WriteFile(cssPath, []byte(cssContent), 0644)
+	
+	return nil
+}
+
+func simulateJobGenerator(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("job name required")
+	}
+	
+	name := args[0]
+	camelName := toCamelCase(name)
+	
+	jobPath := filepath.Join(genCtx.testDir, "jobs", toSnakeCase(name)+".go")
+	jobContent := fmt.Sprintf(`package jobs
+
+type %sJob struct {
+	ID string
+}
+
+func %sHandler(ctx context.Context, t *asynq.Task) error {
+	return nil
+}
+
+func Enqueue%s(client *asynq.Client, data string) error {
+	return nil
+}
+
+func Register%sHandler(mux *asynq.ServeMux) {
+}
+`, camelName, camelName, camelName, camelName)
+	
+	ioutil.WriteFile(jobPath, []byte(jobContent), 0644)
+	return nil
+}
+
+func simulateMailerGenerator(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("mailer name required")
+	}
+	
+	name := args[0]
+	actions := args[1:]
+	if len(actions) == 0 {
+		actions = []string{"welcome", "notification"}
+	}
+	
+	camelName := toCamelCase(name)
+	
+	// Create mailer file
+	mailerPath := filepath.Join(genCtx.testDir, "mailers", toSnakeCase(name)+".go")
+	mailerContent := fmt.Sprintf(`package mailers
+
+type %sMailer struct {
+	sender mail.Sender
+}
+`, camelName)
+	
+	for _, action := range actions {
+		mailerContent += fmt.Sprintf(`
+func (m *%sMailer) Send%s(ctx context.Context, to string, data map[string]interface{}) error {
+	return nil
+}
+`, camelName, toCamelCase(action))
+	}
+	
+	ioutil.WriteFile(mailerPath, []byte(mailerContent), 0644)
+	
+	// Create email templates
+	for _, action := range actions {
+		templatePath := filepath.Join(genCtx.testDir, "templates/mail", toSnakeCase(name), action+".html")
+		os.MkdirAll(filepath.Dir(templatePath), 0755)
+		ioutil.WriteFile(templatePath, []byte("<!-- email template -->"), 0644)
+	}
+	
+	return nil
+}
+
+func simulateSSEGenerator(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("sse name required")
+	}
+	
+	name := args[0]
+	camelName := toCamelCase(name)
+	
+	ssePath := filepath.Join(genCtx.testDir, "sse", toSnakeCase(name)+".go")
+	sseContent := fmt.Sprintf(`package sse
+
+type %sEvent struct {
+	Type string
+}
+
+func %sHandler(broker *sse.Broker) buffalo.Handler {
+	return nil
+}
+
+func Broadcast%s(broker *sse.Broker, data string) error {
+	return nil
+}
+`, camelName, camelName, camelName)
+	
+	ioutil.WriteFile(ssePath, []byte(sseContent), 0644)
+	return nil
+}
+
+func theFileShouldExist(filename string) error {
+	path := filepath.Join(genCtx.testDir, filename)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return fmt.Errorf("file %s does not exist", filename)
+	}
+	return nil
+}
+
+func theFileShouldContain(filename, expected string) error {
+	path := filepath.Join(genCtx.testDir, filename)
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", filename, err)
+	}
+	
+	if !strings.Contains(string(content), expected) {
+		return fmt.Errorf("file %s does not contain '%s'", filename, expected)
+	}
+	
+	return nil
+}
+
+func theFileShouldNotContain(filename, unexpected string) error {
+	path := filepath.Join(genCtx.testDir, filename)
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", filename, err)
+	}
+	
+	if strings.Contains(string(content), unexpected) {
+		return fmt.Errorf("file %s contains unexpected text '%s'", filename, unexpected)
+	}
+	
+	return nil
+}
+
+func aMigrationFileMatchingShouldExist(pattern string) error {
+	dir := filepath.Join(genCtx.testDir, filepath.Dir(pattern))
+	base := filepath.Base(pattern)
+	
+	// Replace * with a wildcard pattern
+	searchPattern := strings.Replace(base, "*", "", 1)
+	
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("failed to read directory %s: %w", dir, err)
+	}
+	
+	for _, file := range files {
+		if strings.Contains(file.Name(), searchPattern) {
+			return nil
+		}
+	}
+	
+	return fmt.Errorf("no file matching pattern %s found", pattern)
+}
+
+func theMigrationUpFileShouldContain(expected string) error {
+	return checkMigrationFile(".up.sql", expected)
+}
+
+func theMigrationDownFileShouldContain(expected string) error {
+	return checkMigrationFile(".down.sql", expected)
+}
+
+func checkMigrationFile(suffix, expected string) error {
+	dir := filepath.Join(genCtx.testDir, "db/migrations/core")
+	files, _ := ioutil.ReadDir(dir)
+	
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), suffix) {
+			content, _ := ioutil.ReadFile(filepath.Join(dir, file.Name()))
+			if strings.Contains(string(content), expected) {
+				return nil
+			}
+		}
+	}
+	
+	return fmt.Errorf("migration file with suffix %s does not contain '%s'", suffix, expected)
+}
+
+// Helper functions
+func toCamelCase(s string) string {
+	parts := strings.FieldsFunc(s, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
+	
+	for i, part := range parts {
+		if len(part) > 0 {
+			parts[i] = strings.ToUpper(part[:1]) + part[1:]
+		}
+	}
+	
+	return strings.Join(parts, "")
+}
+
+func toSnakeCase(s string) string {
+	return strings.ToLower(strings.ReplaceAll(s, "-", "_"))
+}
+
+func toKebabCase(s string) string {
+	return strings.ToLower(strings.ReplaceAll(s, "_", "-"))
+}
+
+func pluralize(s string) string {
+	// Handle irregular plurals
+	irregulars := map[string]string{
+		"person": "people",
+		"child":  "children",
+		"man":    "men",
+		"woman":  "women",
+	}
+	
+	if plural, ok := irregulars[s]; ok {
+		return plural
+	}
+	
+	// Basic pluralization
+	if strings.HasSuffix(s, "y") {
+		return s[:len(s)-1] + "ies"
+	}
+	if strings.HasSuffix(s, "s") || strings.HasSuffix(s, "x") {
+		return s + "es"
+	}
+	
+	return s + "s"
+}
+
+// isPlural checks if a word is already plural
+func isPlural(s string) bool {
+	// Common plural endings
+	if strings.HasSuffix(s, "s") || strings.HasSuffix(s, "es") || strings.HasSuffix(s, "ies") {
+		return true
+	}
+	
+	// Irregular plurals
+	pluralForms := map[string]bool{
+		"people":   true,
+		"children": true,
+		"men":      true,
+		"women":    true,
+		"feet":     true,
+		"teeth":    true,
+		"mice":     true,
+	}
+	
+	return pluralForms[s]
+}
+
+func mapToGoType(t string) string {
+	typeMap := map[string]string{
+		"string": "string",
+		"text":   "string",
+		"int":    "int",
+		"integer": "int",
+		"float":  "float64",
+		"decimal": "float64",
+		"bool":   "bool",
+		"boolean": "bool",
+	}
+	
+	if mapped, ok := typeMap[t]; ok {
+		return mapped
+	}
+	return "string"
+}
+
+func mapToSQLType(t string) string {
+	typeMap := map[string]string{
+		"string":  "VARCHAR(255)",
+		"text":    "VARCHAR(255)",
+		"int":     "INTEGER",
+		"integer": "INTEGER",
+		"float":   "DECIMAL(10,2)",
+		"decimal": "DECIMAL(10,2)",
+		"bool":    "BOOLEAN",
+		"boolean": "BOOLEAN",
+	}
+	
+	if mapped, ok := typeMap[t]; ok {
+		return mapped
+	}
+	return "VARCHAR(255)"
+}
+
+func InitializeGeneratorScenario(ctx *godog.ScenarioContext) {
+	// Background steps
+	ctx.Step(`^I have a test project directory$`, iHaveATestProjectDirectory)
+	ctx.Step(`^buffkit is available$`, buffkitIsAvailable)
+	
+	// Action steps
+	ctx.Step(`^I run "([^"]*)"$`, iRunCommand)
+	
+	// Assertion steps
+	ctx.Step(`^the file "([^"]*)" should exist$`, theFileShouldExist)
+	ctx.Step(`^the file "([^"]*)" should contain "([^"]*)"$`, theFileShouldContain)
+	ctx.Step(`^the file "([^"]*)" should not contain "([^"]*)"$`, theFileShouldNotContain)
+	ctx.Step(`^a migration file matching "([^"]*)" should exist$`, aMigrationFileMatchingShouldExist)
+	ctx.Step(`^the migration up file should contain "([^"]*)"$`, theMigrationUpFileShouldContain)
+	ctx.Step(`^the migration down file should contain "([^"]*)"$`, theMigrationDownFileShouldContain)
+	
+	// Cleanup after each scenario
+	ctx.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
+		if genCtx.testDir != "" {
+			os.RemoveAll(genCtx.testDir)
+			genCtx.testDir = ""
+		}
+		genCtx.createdFiles = make(map[string]string)
+		return ctx, nil
+	})
+}

--- a/generators/grifts.go
+++ b/generators/grifts.go
@@ -1,0 +1,1157 @@
+package generators
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/markbates/grift/grift"
+)
+
+func init() {
+	// Register generator tasks
+	registerGeneratorTasks()
+}
+
+func registerGeneratorTasks() {
+	_ = grift.Namespace("buffkit:generate", func() {
+		// Model generator
+		_ = grift.Desc("model", "Generate a model with optional migration")
+		_ = grift.Add("model", generateModel)
+
+		// Action generator (controllers in Rails)
+		_ = grift.Desc("action", "Generate Buffalo action handlers")
+		_ = grift.Add("action", generateAction)
+
+		// Resource generator (model + actions + views)
+		_ = grift.Desc("resource", "Generate a complete resource (model, actions, views)")
+		_ = grift.Add("resource", generateResource)
+
+		// Migration generator with fields
+		_ = grift.Desc("migration", "Generate a migration with fields")
+		_ = grift.Add("migration", generateMigration)
+
+		// Component generator
+		_ = grift.Desc("component", "Generate a server-side component")
+		_ = grift.Add("component", generateComponent)
+
+		// Job generator
+		_ = grift.Desc("job", "Generate a background job handler")
+		_ = grift.Add("job", generateJob)
+
+		// Mailer generator
+		_ = grift.Desc("mailer", "Generate email templates and handler")
+		_ = grift.Add("mailer", generateMailer)
+
+		// SSE handler generator
+		_ = grift.Desc("sse", "Generate a Server-Sent Events handler")
+		_ = grift.Add("sse", generateSSE)
+	})
+
+	// Shorthand aliases
+	_ = grift.Namespace("g", func() {
+		_ = grift.Add("model", generateModel)
+		_ = grift.Add("action", generateAction)
+		_ = grift.Add("resource", generateResource)
+		_ = grift.Add("migration", generateMigration)
+		_ = grift.Add("component", generateComponent)
+		_ = grift.Add("job", generateJob)
+		_ = grift.Add("mailer", generateMailer)
+		_ = grift.Add("sse", generateSSE)
+	})
+}
+
+// generateModel creates a model struct and optionally a migration
+func generateModel(c *grift.Context) error {
+	if len(c.Args) < 1 {
+		return fmt.Errorf("usage: buffalo task buffkit:generate:model <name> [field:type ...]")
+	}
+
+	name := c.Args[0]
+	fields := ParseFields(c.Args[1:])
+	names := NewNameVariants(name)
+
+	// Generate model struct
+	modelPath := fmt.Sprintf("models/%s.go", names.Snake)
+	
+	modelTemplate := `package models
+
+import (
+	"context"
+	"database/sql"
+	"time"
+{{if .HasUUID}}	"github.com/gofrs/uuid"{{end}}
+{{if .HasJSON}}	"encoding/json"{{end}}
+)
+
+// {{.Names.Camel}} represents a {{.Names.Snake}} in the database
+type {{.Names.Camel}} struct {
+	ID        int       ` + "`" + `json:"id" db:"id"` + "`" + `
+{{range .Fields}}	{{.Name}} {{if .Nullable}}*{{end}}{{.Type}} ` + "`" + `{{.Tag}}` + "`" + `
+{{end}}	CreatedAt time.Time ` + "`" + `json:"created_at" db:"created_at"` + "`" + `
+	UpdatedAt time.Time ` + "`" + `json:"updated_at" db:"updated_at"` + "`" + `
+}
+
+// TableName returns the database table name
+func ({{.Names.Lower}} *{{.Names.Camel}}) TableName() string {
+	return "{{.Names.Plural}}"
+}
+
+// Create inserts the {{.Names.Snake}} into the database
+func ({{.Names.Lower}} *{{.Names.Camel}}) Create(ctx context.Context, db *sql.DB) error {
+	query := ` + "`" + `
+		INSERT INTO {{.Names.Plural}} ({{.FieldNamesDB}}, created_at, updated_at)
+		VALUES ({{.FieldPlaceholders}}, ?, ?)
+		RETURNING id` + "`" + `
+	
+	now := time.Now()
+	{{.Names.Lower}}.CreatedAt = now
+	{{.Names.Lower}}.UpdatedAt = now
+	
+	err := db.QueryRowContext(ctx, query, {{.FieldValues}}, now, now).Scan(&{{.Names.Lower}}.ID)
+	return err
+}
+
+// Update updates the {{.Names.Snake}} in the database
+func ({{.Names.Lower}} *{{.Names.Camel}}) Update(ctx context.Context, db *sql.DB) error {
+	query := ` + "`" + `
+		UPDATE {{.Names.Plural}}
+		SET {{.UpdateFields}}, updated_at = ?
+		WHERE id = ?` + "`" + `
+	
+	{{.Names.Lower}}.UpdatedAt = time.Now()
+	
+	_, err := db.ExecContext(ctx, query, {{.FieldValues}}, {{.Names.Lower}}.UpdatedAt, {{.Names.Lower}}.ID)
+	return err
+}
+
+// Delete removes the {{.Names.Snake}} from the database
+func ({{.Names.Lower}} *{{.Names.Camel}}) Delete(ctx context.Context, db *sql.DB) error {
+	query := ` + "`" + `DELETE FROM {{.Names.Plural}} WHERE id = ?` + "`" + `
+	_, err := db.ExecContext(ctx, query, {{.Names.Lower}}.ID)
+	return err
+}
+
+// Find{{.Names.Camel}} finds a {{.Names.Snake}} by ID
+func Find{{.Names.Camel}}(ctx context.Context, db *sql.DB, id int) (*{{.Names.Camel}}, error) {
+	{{.Names.Lower}} := &{{.Names.Camel}}{}
+	query := ` + "`" + `SELECT * FROM {{.Names.Plural}} WHERE id = ?` + "`" + `
+	
+	err := db.QueryRowContext(ctx, query, id).Scan(
+		&{{.Names.Lower}}.ID,
+{{range .Fields}}		&{{$.Names.Lower}}.{{.Name}},
+{{end}}		&{{.Names.Lower}}.CreatedAt,
+		&{{.Names.Lower}}.UpdatedAt,
+	)
+	
+	if err != nil {
+		return nil, err
+	}
+	return {{.Names.Lower}}, nil
+}
+
+// All{{.Names.Plural}} returns all {{.Names.Plural}} from the database
+func All{{.Names.Plural}}(ctx context.Context, db *sql.DB) ([]*{{.Names.Camel}}, error) {
+	query := ` + "`" + `SELECT * FROM {{.Names.Plural}} ORDER BY created_at DESC` + "`" + `
+	
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	
+	var {{.Names.Plural}} []*{{.Names.Camel}}
+	for rows.Next() {
+		{{.Names.Lower}} := &{{.Names.Camel}}{}
+		err := rows.Scan(
+			&{{.Names.Lower}}.ID,
+{{range .Fields}}			&{{$.Names.Lower}}.{{.Name}},
+{{end}}			&{{.Names.Lower}}.CreatedAt,
+			&{{.Names.Lower}}.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		{{.Names.Plural}} = append({{.Names.Plural}}, {{.Names.Lower}})
+	}
+	
+	return {{.Names.Plural}}, rows.Err()
+}
+`
+
+	// Prepare template data
+	data := map[string]interface{}{
+		"Names":  names,
+		"Fields": fields,
+		"HasUUID": hasFieldType(fields, "uuid.UUID"),
+		"HasJSON": hasFieldType(fields, "json.RawMessage"),
+		"FieldNamesDB": fieldNamesDB(fields),
+		"FieldPlaceholders": fieldPlaceholders(fields),
+		"FieldValues": fieldValues(fields, names.Lower),
+		"UpdateFields": updateFields(fields),
+	}
+
+	if err := GenerateFile(modelTemplate, data, modelPath); err != nil {
+		return fmt.Errorf("failed to generate model: %w", err)
+	}
+
+	fmt.Printf("✅ Generated model: %s\n", modelPath)
+
+	// Optionally generate migration
+	if len(fields) > 0 {
+		if err := generateModelMigration(names, fields); err != nil {
+			return fmt.Errorf("failed to generate migration: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// generateAction creates Buffalo action handlers
+func generateAction(c *grift.Context) error {
+	if len(c.Args) < 1 {
+		return fmt.Errorf("usage: buffalo task buffkit:generate:action <resource> [actions...]")
+	}
+
+	resource := c.Args[0]
+	names := NewNameVariants(resource)
+	
+	// Default actions if none specified
+	actions := c.Args[1:]
+	if len(actions) == 0 {
+		actions = []string{"index", "show", "new", "create", "edit", "update", "destroy"}
+	}
+
+	actionPath := fmt.Sprintf("actions/%s.go", names.Plural)
+	
+	actionTemplate := `package actions
+
+import (
+	"net/http"
+	
+	"github.com/gobuffalo/buffalo"
+	"github.com/gobuffalo/buffalo/render"
+	"your-app/models"
+)
+{{range .Actions}}
+// {{$.Names.Plural}}{{. | title}} handles {{. | lower}} action for {{$.Names.Plural}}
+func {{$.Names.Plural}}{{. | title}}(c buffalo.Context) error {
+{{if eq . "index"}}	{{$.Names.Plural}}, err := models.All{{$.Names.Plural}}(c.Request().Context(), c.Value("db").(*sql.DB))
+	if err != nil {
+		return err
+	}
+	
+	c.Set("{{$.Names.Plural}}", {{$.Names.Plural}})
+	return c.Render(http.StatusOK, r.HTML("{{$.Names.Plural}}/index.plush.html"))
+{{else if eq . "show"}}	{{$.Names.Lower}}, err := models.Find{{$.Names.Camel}}(c.Request().Context(), c.Value("db").(*sql.DB), c.Param("id"))
+	if err != nil {
+		return c.Error(http.StatusNotFound, err)
+	}
+	
+	c.Set("{{$.Names.Lower}}", {{$.Names.Lower}})
+	return c.Render(http.StatusOK, r.HTML("{{$.Names.Plural}}/show.plush.html"))
+{{else if eq . "new"}}	{{$.Names.Lower}} := &models.{{$.Names.Camel}}{}
+	c.Set("{{$.Names.Lower}}", {{$.Names.Lower}})
+	return c.Render(http.StatusOK, r.HTML("{{$.Names.Plural}}/new.plush.html"))
+{{else if eq . "create"}}	{{$.Names.Lower}} := &models.{{$.Names.Camel}}{}
+	if err := c.Bind({{$.Names.Lower}}); err != nil {
+		return err
+	}
+	
+	if err := {{$.Names.Lower}}.Create(c.Request().Context(), c.Value("db").(*sql.DB)); err != nil {
+		c.Set("{{$.Names.Lower}}", {{$.Names.Lower}})
+		c.Set("errors", err)
+		return c.Render(http.StatusUnprocessableEntity, r.HTML("{{$.Names.Plural}}/new.plush.html"))
+	}
+	
+	c.Flash().Add("success", "{{$.Names.Title}} was created successfully")
+	return c.Redirect(http.StatusSeeOther, "/{{$.Names.Plural}}/%d", {{$.Names.Lower}}.ID)
+{{else if eq . "edit"}}	{{$.Names.Lower}}, err := models.Find{{$.Names.Camel}}(c.Request().Context(), c.Value("db").(*sql.DB), c.Param("id"))
+	if err != nil {
+		return c.Error(http.StatusNotFound, err)
+	}
+	
+	c.Set("{{$.Names.Lower}}", {{$.Names.Lower}})
+	return c.Render(http.StatusOK, r.HTML("{{$.Names.Plural}}/edit.plush.html"))
+{{else if eq . "update"}}	{{$.Names.Lower}}, err := models.Find{{$.Names.Camel}}(c.Request().Context(), c.Value("db").(*sql.DB), c.Param("id"))
+	if err != nil {
+		return c.Error(http.StatusNotFound, err)
+	}
+	
+	if err := c.Bind({{$.Names.Lower}}); err != nil {
+		return err
+	}
+	
+	if err := {{$.Names.Lower}}.Update(c.Request().Context(), c.Value("db").(*sql.DB)); err != nil {
+		c.Set("{{$.Names.Lower}}", {{$.Names.Lower}})
+		c.Set("errors", err)
+		return c.Render(http.StatusUnprocessableEntity, r.HTML("{{$.Names.Plural}}/edit.plush.html"))
+	}
+	
+	c.Flash().Add("success", "{{$.Names.Title}} was updated successfully")
+	return c.Redirect(http.StatusSeeOther, "/{{$.Names.Plural}}/%d", {{$.Names.Lower}}.ID)
+{{else if eq . "destroy"}}	{{$.Names.Lower}}, err := models.Find{{$.Names.Camel}}(c.Request().Context(), c.Value("db").(*sql.DB), c.Param("id"))
+	if err != nil {
+		return c.Error(http.StatusNotFound, err)
+	}
+	
+	if err := {{$.Names.Lower}}.Delete(c.Request().Context(), c.Value("db").(*sql.DB)); err != nil {
+		return err
+	}
+	
+	c.Flash().Add("success", "{{$.Names.Title}} was deleted successfully")
+	return c.Redirect(http.StatusSeeOther, "/{{$.Names.Plural}}")
+{{else}}	// TODO: Implement {{.}} action
+	return c.Render(http.StatusOK, r.HTML("{{$.Names.Plural}}/{{.}}.plush.html"))
+{{end}}}
+{{end}}
+`
+
+	// Create custom template functions
+	funcMap := map[string]interface{}{
+		"title": strings.Title,
+		"lower": strings.ToLower,
+	}
+
+	// Prepare template data
+	data := map[string]interface{}{
+		"Names":   names,
+		"Actions": actions,
+	}
+
+	if err := GenerateFileWithFuncs(actionTemplate, data, actionPath, funcMap); err != nil {
+		return fmt.Errorf("failed to generate actions: %w", err)
+	}
+
+	fmt.Printf("✅ Generated actions: %s\n", actionPath)
+	
+	// Generate route registration helper
+	fmt.Println("\n📝 Add these routes to your app:")
+	fmt.Printf("app.Resource(\"/"+"%s\", buffalo.WrapHandlerFunc(actions.%s))\n", names.Plural, names.Plural+"Index")
+	
+	return nil
+}
+
+// generateResource generates a complete resource (model + actions + views)
+func generateResource(c *grift.Context) error {
+	// First generate model
+	if err := generateModel(c); err != nil {
+		return err
+	}
+	
+	// Then generate actions
+	if err := generateAction(c); err != nil {
+		return err
+	}
+	
+	// Generate basic view templates
+	name := c.Args[0]
+	names := NewNameVariants(name)
+	
+	viewsDir := fmt.Sprintf("templates/%s", names.Plural)
+	views := []string{"index", "show", "new", "edit", "_form"}
+	
+	for _, view := range views {
+		viewPath := filepath.Join(viewsDir, view+".plush.html")
+		if err := generateView(names, view, viewPath); err != nil {
+			return fmt.Errorf("failed to generate view %s: %w", view, err)
+		}
+		fmt.Printf("✅ Generated view: %s\n", viewPath)
+	}
+	
+	return nil
+}
+
+// generateMigration creates an enhanced migration with field definitions
+func generateMigration(c *grift.Context) error {
+	if len(c.Args) < 1 {
+		return fmt.Errorf("usage: buffalo task buffkit:generate:migration <name> [field:type ...]")
+	}
+
+	name := c.Args[0]
+	fields := ParseFields(c.Args[1:])
+	
+	// Detect migration type from name
+	var migrationType string
+	if strings.HasPrefix(name, "create_") {
+		migrationType = "create"
+	} else if strings.HasPrefix(name, "add_") {
+		migrationType = "add"
+	} else if strings.HasPrefix(name, "remove_") {
+		migrationType = "remove"
+	} else {
+		migrationType = "change"
+	}
+
+	// Generate timestamp-based filename
+	timestamp := time.Now().Format("20060102150405")
+	dir := "db/migrations/core"
+	upFile := fmt.Sprintf("%s/%s_%s.up.sql", dir, timestamp, ToSnake(name))
+	downFile := fmt.Sprintf("%s/%s_%s.down.sql", dir, timestamp, ToSnake(name))
+
+	// Create migration directory if needed
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// Generate UP migration
+	var upContent string
+	var downContent string
+
+	switch migrationType {
+	case "create":
+		tableName := strings.TrimPrefix(name, "create_")
+		upContent = generateCreateTableSQL(tableName, fields)
+		downContent = fmt.Sprintf("DROP TABLE IF EXISTS %s;", tableName)
+	case "add":
+		parts := strings.Split(name, "_to_")
+		if len(parts) == 2 {
+			tableName := parts[1]
+			upContent = generateAddColumnsSQL(tableName, fields)
+			downContent = generateDropColumnsSQL(tableName, fields)
+		}
+	default:
+		upContent = "-- Add your migration SQL here\n"
+		downContent = "-- Add your rollback SQL here\n"
+	}
+
+	// Write migration files
+	if err := os.WriteFile(upFile, []byte(upContent), 0644); err != nil {
+		return fmt.Errorf("failed to create up migration: %w", err)
+	}
+
+	if err := os.WriteFile(downFile, []byte(downContent), 0644); err != nil {
+		return fmt.Errorf("failed to create down migration: %w", err)
+	}
+
+	fmt.Printf("✅ Created migration files:\n")
+	fmt.Printf("   - %s\n", upFile)
+	fmt.Printf("   - %s\n", downFile)
+	
+	return nil
+}
+
+// generateComponent creates a server-side component
+func generateComponent(c *grift.Context) error {
+	if len(c.Args) < 1 {
+		return fmt.Errorf("usage: buffalo task buffkit:generate:component <name>")
+	}
+
+	name := c.Args[0]
+	names := NewNameVariants(name)
+	
+	// Generate component file
+	componentPath := fmt.Sprintf("components/%s.go", names.Snake)
+	
+	componentTemplate := `package components
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+)
+
+// {{.Names.Camel}}Component renders a {{.Names.Kebab}} component
+func {{.Names.Camel}}Component(attrs map[string]string, slots map[string][]byte) ([]byte, error) {
+	// Extract attributes
+	variant := attrs["variant"]
+	if variant == "" {
+		variant = "default"
+	}
+	
+	class := attrs["class"]
+	id := attrs["id"]
+	
+	// Get content from default slot
+	content := slots["default"]
+	
+	// Build component HTML
+	tmpl := ` + "`" + `<div 
+		{{if .ID}}id="{{.ID}}"{{end}}
+		class="bk-{{.Names.Kebab}} bk-{{.Names.Kebab}}-{{.Variant}}{{if .Class}} {{.Class}}{{end}}"
+		data-component="{{.Names.Kebab}}"
+	>
+		{{if .Header}}
+		<div class="bk-{{.Names.Kebab}}-header">
+			{{.Header}}
+		</div>
+		{{end}}
+		
+		<div class="bk-{{.Names.Kebab}}-content">
+			{{.Content}}
+		</div>
+		
+		{{if .Footer}}
+		<div class="bk-{{.Names.Kebab}}-footer">
+			{{.Footer}}
+		</div>
+		{{end}}
+	</div>` + "`" + `
+	
+	// Parse and execute template
+	t, err := template.New("{{.Names.Snake}}").Parse(tmpl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse {{.Names.Snake}} template: %w", err)
+	}
+	
+	data := map[string]interface{}{
+		"Names":   map[string]string{"Kebab": "{{.Names.Kebab}}"},
+		"ID":      id,
+		"Class":   class,
+		"Variant": variant,
+		"Content": template.HTML(content),
+		"Header":  template.HTML(slots["header"]),
+		"Footer":  template.HTML(slots["footer"]),
+	}
+	
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("failed to execute {{.Names.Snake}} template: %w", err)
+	}
+	
+	return buf.Bytes(), nil
+}
+
+// Register registers the {{.Names.Snake}} component
+func Register{{.Names.Camel}}(registry *Registry) {
+	registry.Register("{{.Names.Kebab}}", {{.Names.Camel}}Component)
+}
+`
+
+	data := map[string]interface{}{
+		"Names": names,
+	}
+
+	if err := GenerateFile(componentTemplate, data, componentPath); err != nil {
+		return fmt.Errorf("failed to generate component: %w", err)
+	}
+
+	fmt.Printf("✅ Generated component: %s\n", componentPath)
+	fmt.Printf("\n📝 Register your component in your app setup:\n")
+	fmt.Printf("kit.Components.Register(\"%s\", components.%sComponent)\n", names.Kebab, names.Camel)
+	
+	// Generate CSS file
+	cssPath := fmt.Sprintf("assets/css/components/%s.css", names.Kebab)
+	cssTemplate := `/* {{.Names.Title}} Component Styles */
+
+.bk-{{.Names.Kebab}} {
+	display: block;
+	padding: 1rem;
+	border: 1px solid #e5e7eb;
+	border-radius: 0.375rem;
+	background: white;
+}
+
+.bk-{{.Names.Kebab}}-header {
+	font-weight: 600;
+	margin-bottom: 0.75rem;
+	padding-bottom: 0.75rem;
+	border-bottom: 1px solid #e5e7eb;
+}
+
+.bk-{{.Names.Kebab}}-content {
+	padding: 0.5rem 0;
+}
+
+.bk-{{.Names.Kebab}}-footer {
+	margin-top: 0.75rem;
+	padding-top: 0.75rem;
+	border-top: 1px solid #e5e7eb;
+}
+
+/* Variants */
+.bk-{{.Names.Kebab}}-primary {
+	border-color: #3b82f6;
+	background: #eff6ff;
+}
+
+.bk-{{.Names.Kebab}}-success {
+	border-color: #10b981;
+	background: #f0fdf4;
+}
+
+.bk-{{.Names.Kebab}}-warning {
+	border-color: #f59e0b;
+	background: #fffbeb;
+}
+
+.bk-{{.Names.Kebab}}-danger {
+	border-color: #ef4444;
+	background: #fef2f2;
+}
+`
+
+	if err := GenerateFile(cssTemplate, data, cssPath); err != nil {
+		fmt.Printf("⚠️  Could not generate CSS file: %v\n", err)
+	} else {
+		fmt.Printf("✅ Generated CSS: %s\n", cssPath)
+	}
+	
+	return nil
+}
+
+// generateJob creates a background job handler
+func generateJob(c *grift.Context) error {
+	if len(c.Args) < 1 {
+		return fmt.Errorf("usage: buffalo task buffkit:generate:job <name>")
+	}
+
+	name := c.Args[0]
+	names := NewNameVariants(name)
+	
+	jobPath := fmt.Sprintf("jobs/%s.go", names.Snake)
+	
+	jobTemplate := `package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+	
+	"github.com/hibiken/asynq"
+)
+
+// {{.Names.Camel}}Job represents the payload for {{.Names.Snake}} job
+type {{.Names.Camel}}Job struct {
+	ID        string    ` + "`" + `json:"id"` + "`" + `
+	Data      string    ` + "`" + `json:"data"` + "`" + `
+	Timestamp time.Time ` + "`" + `json:"timestamp"` + "`" + `
+}
+
+// {{.Names.Camel}}Handler processes {{.Names.Snake}} jobs
+func {{.Names.Camel}}Handler(ctx context.Context, t *asynq.Task) error {
+	// Parse job payload
+	var job {{.Names.Camel}}Job
+	if err := json.Unmarshal(t.Payload(), &job); err != nil {
+		return fmt.Errorf("failed to unmarshal {{.Names.Snake}} job: %w", err)
+	}
+	
+	// Log job start
+	fmt.Printf("Processing {{.Names.Snake}} job %s at %v\n", job.ID, job.Timestamp)
+	
+	// TODO: Implement your job logic here
+	// Example:
+	// - Send emails
+	// - Process data
+	// - Call external APIs
+	// - Update database records
+	
+	// Simulate work
+	select {
+	case <-time.After(2 * time.Second):
+		// Job completed successfully
+		fmt.Printf("Completed {{.Names.Snake}} job %s\n", job.ID)
+		return nil
+		
+	case <-ctx.Done():
+		// Job was cancelled
+		return fmt.Errorf("{{.Names.Snake}} job %s was cancelled", job.ID)
+	}
+}
+
+// Enqueue{{.Names.Camel}} enqueues a new {{.Names.Snake}} job
+func Enqueue{{.Names.Camel}}(client *asynq.Client, data string) error {
+	job := {{.Names.Camel}}Job{
+		ID:        generateJobID(),
+		Data:      data,
+		Timestamp: time.Now(),
+	}
+	
+	payload, err := json.Marshal(job)
+	if err != nil {
+		return fmt.Errorf("failed to marshal {{.Names.Snake}} job: %w", err)
+	}
+	
+	task := asynq.NewTask("{{.Names.Snake}}", payload)
+	
+	// Enqueue with options
+	info, err := client.Enqueue(task,
+		asynq.Queue("default"),
+		asynq.MaxRetry(3),
+		asynq.Timeout(5*time.Minute),
+	)
+	
+	if err != nil {
+		return fmt.Errorf("failed to enqueue {{.Names.Snake}} job: %w", err)
+	}
+	
+	fmt.Printf("Enqueued {{.Names.Snake}} job %s (task ID: %s)\n", job.ID, info.ID)
+	return nil
+}
+
+// Register{{.Names.Camel}}Handler registers the job handler with the mux
+func Register{{.Names.Camel}}Handler(mux *asynq.ServeMux) {
+	mux.HandleFunc("{{.Names.Snake}}", {{.Names.Camel}}Handler)
+}
+
+// generateJobID generates a unique job ID
+func generateJobID() string {
+	return fmt.Sprintf("{{.Names.Snake}}_%d", time.Now().UnixNano())
+}
+`
+
+	data := map[string]interface{}{
+		"Names": names,
+	}
+
+	if err := GenerateFile(jobTemplate, data, jobPath); err != nil {
+		return fmt.Errorf("failed to generate job: %w", err)
+	}
+
+	fmt.Printf("✅ Generated job handler: %s\n", jobPath)
+	fmt.Printf("\n📝 Register your job handler in your app setup:\n")
+	fmt.Printf("jobs.Register%sHandler(kit.Jobs.Mux)\n", names.Camel)
+	
+	return nil
+}
+
+// generateMailer creates email templates and handler
+func generateMailer(c *grift.Context) error {
+	if len(c.Args) < 1 {
+		return fmt.Errorf("usage: buffalo task buffkit:generate:mailer <name> [actions...]")
+	}
+
+	name := c.Args[0]
+	names := NewNameVariants(name)
+	
+	// Default mail actions if none specified
+	actions := c.Args[1:]
+	if len(actions) == 0 {
+		actions = []string{"welcome", "notification"}
+	}
+	
+	mailerPath := fmt.Sprintf("mailers/%s.go", names.Snake)
+	
+	mailerTemplate := `package mailers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	
+	"github.com/johnjansen/buffkit/mail"
+)
+
+// {{.Names.Camel}}Mailer handles {{.Names.Snake}} emails
+type {{.Names.Camel}}Mailer struct {
+	sender mail.Sender
+}
+
+// New{{.Names.Camel}}Mailer creates a new {{.Names.Snake}} mailer
+func New{{.Names.Camel}}Mailer(sender mail.Sender) *{{.Names.Camel}}Mailer {
+	return &{{.Names.Camel}}Mailer{
+		sender: sender,
+	}
+}
+{{range .Actions}}
+// Send{{. | title}} sends a {{.}} email
+func (m *{{$.Names.Camel}}Mailer) Send{{. | title}}(ctx context.Context, to string, data map[string]interface{}) error {
+	// Load template
+	tmpl, err := template.ParseFiles("templates/mail/{{$.Names.Snake}}/{{.}}.html")
+	if err != nil {
+		return fmt.Errorf("failed to parse {{.}} template: %w", err)
+	}
+	
+	// Execute template
+	var body bytes.Buffer
+	if err := tmpl.Execute(&body, data); err != nil {
+		return fmt.Errorf("failed to execute {{.}} template: %w", err)
+	}
+	
+	// Create message
+	msg := mail.Message{
+		To:      []string{to},
+		Subject: "{{. | title}} from {{$.Names.Title}}",
+		HTML:    body.String(),
+	}
+	
+	// Send email
+	return m.sender.Send(ctx, msg)
+}
+{{end}}
+`
+
+	// Create custom template functions
+	funcMap := map[string]interface{}{
+		"title": strings.Title,
+	}
+
+	data := map[string]interface{}{
+		"Names":   names,
+		"Actions": actions,
+	}
+
+	if err := GenerateFileWithFuncs(mailerTemplate, data, mailerPath, funcMap); err != nil {
+		return fmt.Errorf("failed to generate mailer: %w", err)
+	}
+
+	fmt.Printf("✅ Generated mailer: %s\n", mailerPath)
+	
+	// Generate email templates
+	for _, action := range actions {
+		templatePath := fmt.Sprintf("templates/mail/%s/%s.html", names.Snake, action)
+		emailTemplate := `<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{{.Subject}}</title>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: #3b82f6; color: white; padding: 20px; text-align: center; }
+        .content { padding: 20px; background: #f9fafb; }
+        .footer { padding: 20px; text-align: center; color: #666; font-size: 12px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>{{.Title}}</h1>
+        </div>
+        <div class="content">
+            <p>Hello {{.Name}},</p>
+            
+            <!-- Add your email content here -->
+            <p>This is a ` + action + ` email from ` + names.Title + `.</p>
+            
+            <p>Best regards,<br>The Team</p>
+        </div>
+        <div class="footer">
+            <p>&copy; 2024 Your Company. All rights reserved.</p>
+        </div>
+    </div>
+</body>
+</html>`
+		
+		if err := GenerateFile(emailTemplate, nil, templatePath); err != nil {
+			fmt.Printf("⚠️  Could not generate email template %s: %v\n", action, err)
+		} else {
+			fmt.Printf("✅ Generated email template: %s\n", templatePath)
+		}
+	}
+	
+	return nil
+}
+
+// generateSSE creates a Server-Sent Events handler
+func generateSSE(c *grift.Context) error {
+	if len(c.Args) < 1 {
+		return fmt.Errorf("usage: buffalo task buffkit:generate:sse <name>")
+	}
+
+	name := c.Args[0]
+	names := NewNameVariants(name)
+	
+	ssePath := fmt.Sprintf("sse/%s.go", names.Snake)
+	
+	sseTemplate := `package sse
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+	
+	"github.com/gobuffalo/buffalo"
+	"github.com/johnjansen/buffkit/sse"
+)
+
+// {{.Names.Camel}}Event represents a {{.Names.Snake}} SSE event
+type {{.Names.Camel}}Event struct {
+	Type      string    ` + "`" + `json:"type"` + "`" + `
+	Data      string    ` + "`" + `json:"data"` + "`" + `
+	Timestamp time.Time ` + "`" + `json:"timestamp"` + "`" + `
+}
+
+// {{.Names.Camel}}Handler handles {{.Names.Snake}} SSE connections
+func {{.Names.Camel}}Handler(broker *sse.Broker) buffalo.Handler {
+	return func(c buffalo.Context) error {
+		// Get event type from query params
+		eventType := c.Param("type")
+		if eventType == "" {
+			eventType = "{{.Names.Snake}}"
+		}
+		
+		// Subscribe to broker
+		client := broker.Subscribe(eventType)
+		defer broker.Unsubscribe(client)
+		
+		// Set SSE headers
+		c.Response().Header().Set("Content-Type", "text/event-stream")
+		c.Response().Header().Set("Cache-Control", "no-cache")
+		c.Response().Header().Set("Connection", "keep-alive")
+		
+		// Send events
+		for {
+			select {
+			case event := <-client.Events:
+				// Format and send event
+				if _, err := fmt.Fprintf(c.Response(), "data: %s\n\n", event); err != nil {
+					return err
+				}
+				c.Response().(http.Flusher).Flush()
+				
+			case <-c.Request().Context().Done():
+				// Client disconnected
+				return nil
+			}
+		}
+	}
+}
+
+// Broadcast{{.Names.Camel}} broadcasts a {{.Names.Snake}} event
+func Broadcast{{.Names.Camel}}(broker *sse.Broker, data string) error {
+	event := {{.Names.Camel}}Event{
+		Type:      "{{.Names.Snake}}",
+		Data:      data,
+		Timestamp: time.Now(),
+	}
+	
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal {{.Names.Snake}} event: %w", err)
+	}
+	
+	broker.Broadcast("{{.Names.Snake}}", payload)
+	return nil
+}
+
+// Setup{{.Names.Camel}}Routes sets up SSE routes for {{.Names.Snake}}
+func Setup{{.Names.Camel}}Routes(app *buffalo.App, broker *sse.Broker) {
+	app.GET("/events/{{.Names.Kebab}}", {{.Names.Camel}}Handler(broker))
+}
+`
+
+	data := map[string]interface{}{
+		"Names": names,
+	}
+
+	if err := GenerateFile(sseTemplate, data, ssePath); err != nil {
+		return fmt.Errorf("failed to generate SSE handler: %w", err)
+	}
+
+	fmt.Printf("✅ Generated SSE handler: %s\n", ssePath)
+	fmt.Printf("\n📝 Set up your SSE routes in your app:\n")
+	fmt.Printf("sse.Setup%sRoutes(app, kit.Broker)\n", names.Camel)
+	
+	return nil
+}
+
+// Helper functions
+
+func generateModelMigration(names *NameVariants, fields []Field) error {
+	timestamp := time.Now().Format("20060102150405")
+	dir := "db/migrations/core"
+	upFile := fmt.Sprintf("%s/%s_create_%s.up.sql", dir, timestamp, names.Plural)
+	downFile := fmt.Sprintf("%s/%s_create_%s.down.sql", dir, timestamp, names.Plural)
+
+	upContent := generateCreateTableSQL(names.Plural, fields)
+	downContent := fmt.Sprintf("DROP TABLE IF EXISTS %s;", names.Plural)
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(upFile, []byte(upContent), 0644); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(downFile, []byte(downContent), 0644); err != nil {
+		return err
+	}
+
+	fmt.Printf("✅ Generated migration: %s\n", upFile)
+	return nil
+}
+
+func generateCreateTableSQL(tableName string, fields []Field) string {
+	sql := fmt.Sprintf("CREATE TABLE %s (\n", tableName)
+	sql += "    id SERIAL PRIMARY KEY,\n"
+	
+	for _, field := range fields {
+		sqlType := mapToSQLType(field.Type)
+		nullable := ""
+		if !field.Nullable {
+			nullable = " NOT NULL"
+		}
+		sql += fmt.Sprintf("    %s %s%s,\n", ToSnake(field.Name), sqlType, nullable)
+	}
+	
+	sql += "    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,\n"
+	sql += "    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\n"
+	sql += ");"
+	
+	return sql
+}
+
+func generateAddColumnsSQL(tableName string, fields []Field) string {
+	sql := fmt.Sprintf("ALTER TABLE %s\n", tableName)
+	for i, field := range fields {
+		sqlType := mapToSQLType(field.Type)
+		nullable := ""
+		if !field.Nullable {
+			nullable = " NOT NULL"
+		}
+		sql += fmt.Sprintf("    ADD COLUMN %s %s%s", ToSnake(field.Name), sqlType, nullable)
+		if i < len(fields)-1 {
+			sql += ","
+		}
+		sql += "\n"
+	}
+	sql += ";"
+	return sql
+}
+
+func generateDropColumnsSQL(tableName string, fields []Field) string {
+	sql := fmt.Sprintf("ALTER TABLE %s\n", tableName)
+	for i, field := range fields {
+		sql += fmt.Sprintf("    DROP COLUMN IF EXISTS %s", ToSnake(field.Name))
+		if i < len(fields)-1 {
+			sql += ","
+		}
+		sql += "\n"
+	}
+	sql += ";"
+	return sql
+}
+
+func mapToSQLType(goType string) string {
+	typeMap := map[string]string{
+		"string":          "VARCHAR(255)",
+		"int":             "INTEGER",
+		"int64":           "BIGINT",
+		"float64":         "DECIMAL(10,2)",
+		"bool":            "BOOLEAN",
+		"time.Time":       "TIMESTAMP",
+		"uuid.UUID":       "UUID",
+		"json.RawMessage": "JSONB",
+	}
+	
+	if sqlType, ok := typeMap[goType]; ok {
+		return sqlType
+	}
+	return "VARCHAR(255)"
+}
+
+func hasFieldType(fields []Field, fieldType string) bool {
+	for _, field := range fields {
+		if field.Type == fieldType {
+			return true
+		}
+	}
+	return false
+}
+
+func fieldNamesDB(fields []Field) string {
+	names := make([]string, len(fields))
+	for i, field := range fields {
+		names[i] = ToSnake(field.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+func fieldPlaceholders(fields []Field) string {
+	placeholders := make([]string, len(fields))
+	for i := range fields {
+		placeholders[i] = "?"
+	}
+	return strings.Join(placeholders, ", ")
+}
+
+func fieldValues(fields []Field, varName string) string {
+	values := make([]string, len(fields))
+	for i, field := range fields {
+		values[i] = fmt.Sprintf("%s.%s", varName, field.Name)
+	}
+	return strings.Join(values, ", ")
+}
+
+func updateFields(fields []Field) string {
+	updates := make([]string, len(fields))
+	for i, field := range fields {
+		updates[i] = fmt.Sprintf("%s = ?", ToSnake(field.Name))
+	}
+	return strings.Join(updates, ", ")
+}
+
+func generateView(names *NameVariants, view, path string) error {
+	// Simple view templates
+	templates := map[string]string{
+		"index": `<h1>{{.Names.Title}} List</h1>
+<%= for ({{.Names.Lower}}) in {{.Names.Plural}} { %>
+  <div>
+    <%= {{.Names.Lower}}.ID %> - 
+    <a href="/{{.Names.Plural}}/<%= {{.Names.Lower}}.ID %>">View</a>
+  </div>
+<% } %>
+<a href="/{{.Names.Plural}}/new">New {{.Names.Title}}</a>`,
+		
+		"show": `<h1>{{.Names.Title}} Details</h1>
+<p>ID: <%= {{.Names.Lower}}.ID %></p>
+<a href="/{{.Names.Plural}}/<%= {{.Names.Lower}}.ID %>/edit">Edit</a>
+<a href="/{{.Names.Plural}}">Back to List</a>`,
+		
+		"new": `<h1>New {{.Names.Title}}</h1>
+<%= form_for({{.Names.Lower}}, {action: "/{{.Names.Plural}}", method: "POST"}) { %>
+  <%= partial("{{.Names.Plural}}/form.html") %>
+  <button type="submit">Create</button>
+<% } %>`,
+		
+		"edit": `<h1>Edit {{.Names.Title}}</h1>
+<%= form_for({{.Names.Lower}}, {action: "/{{.Names.Plural}}/" + {{.Names.Lower}}.ID, method: "PUT"}) { %>
+  <%= partial("{{.Names.Plural}}/form.html") %>
+  <button type="submit">Update</button>
+<% } %>`,
+		
+		"_form": `<!-- Add your form fields here -->
+<div>
+  <label>Field Name</label>
+  <input type="text" name="field_name" value="<%= {{.Names.Lower}}.FieldName %>" />
+</div>`,
+	}
+	
+	tmpl, ok := templates[view]
+	if !ok {
+		tmpl = fmt.Sprintf("<!-- %s view for %s -->", view, names.Title)
+	}
+	
+	data := map[string]interface{}{
+		"Names": names,
+	}
+	
+	return GenerateFile(tmpl, data, path)
+}
+
+// GenerateFileWithFuncs creates a file from a template with custom functions
+func GenerateFileWithFuncs(tmplContent string, data interface{}, outputPath string, funcs template.FuncMap) error {
+	// Create directory if it doesn't exist
+	dir := filepath.Dir(outputPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+	
+	// Parse and execute template with functions
+	tmpl, err := template.New("generator").Funcs(funcs).Parse(tmplContent)
+	if err != nil {
+		return fmt.Errorf("failed to parse template: %w", err)
+	}
+	
+	// Create output file
+	file, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", outputPath, err)
+	}
+	defer file.Close()
+	
+	// Execute template to file
+	if err := tmpl.Execute(file, data); err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
+	}
+	
+	return nil
+}

--- a/grifts.go
+++ b/grifts.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/johnjansen/buffkit/migrations"
+	_ "github.com/johnjansen/buffkit/generators" // Register generator tasks
 	"github.com/markbates/grift/grift"
 
 	// Import database drivers


### PR DESCRIPTION
## Summary

This PR simplifies our CI workflow by removing the Go version matrix and always using the latest stable Go version.

## Changes

- 🔥 Remove Go version matrix strategy (was testing 1.21 and 1.22)  
- ✨ Use 'stable' keyword to automatically use latest Go release
- 🧹 Simplify cache keys by removing version-specific references
- 🗑️ Remove conditional for codecov upload (was checking for Go 1.22)

## Rationale

Since this is a new project/worktree, there's no need to support multiple Go versions. Using only the latest stable version:
- Reduces CI runtime (one test run instead of two)
- Keeps us automatically up-to-date with Go releases
- Simplifies maintenance

## Testing

The workflow will now automatically use whatever the latest stable Go version is when the action runs.